### PR TITLE
Refs #41 - Disable demo/account.py

### DIFF
--- a/demo/accounts.py
+++ b/demo/accounts.py
@@ -118,6 +118,7 @@ account_input = {
 account_data = client.post_account(account_input)
 print("   Received data: {data}".format(data=account_data))
 
+raw_input("Please activate account {} and type RET".format(account_email))
 
 # Get subsidiary account information.
 print("4. GET /accounts/{accountId}".format(

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ commands =
     nosetests --with-doctest --no-path-adjustment --nocapture --with-coverage --cover-package=pydocusign --all-modules --rednose --verbosity=2 pydocusign tests
     python demo/embeddedsigning.py
     python demo/templates.py
-    python demo/accounts.py
     coverage erase
     pip freeze
 


### PR DESCRIPTION
Please reenable it in another PR when this is fixed. Because it's a blocker for other dev that does not rely on account.